### PR TITLE
FIX - docs reference case sensitive

### DIFF
--- a/docs/vector-search-quickstart.md
+++ b/docs/vector-search-quickstart.md
@@ -208,7 +208,7 @@ api-key: {{admin-api-key}}
 
 ## Run queries
 
-Use the [Search Documents](/docs/rest-api-reference/search-documents.md) REST API for this request. Recall that the private preview has [several limitations](../README.MD#private-preview-limitations) related to queries:
+Use the [Search Documents](/docs/rest-api-reference/search-documents.md) REST API for this request. Recall that the private preview has [several limitations](../README.md#private-preview-limitations) related to queries:
 
 + POST is required for this preview and the API version must be 2023-07-01-Preview
 + Only one vector field per query at this time (for example, either "titleVector" or "contentVector", but not both)


### PR DESCRIPTION
Change reference from README.MD to README.md as this is a case sensitive reference.