### PR TITLE
Lock down azure-search-documents SDK package version

### DIFF
--- a/demo-python/code/azure-search-vector-python-langchain-sample.ipynb
+++ b/demo-python/code/azure-search-vector-python-langchain-sample.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Azure Cognitive Search LangChain Vector Code Sample\n",
     "This code demonstrates how to use Azure Cognitive Search with OpenAI and the Azure Cognitive Search LangChain Vector Store\n",
-    "To run the code, install the following packages. Please use the latest pre-release version `pip install azure-search-documents --pre`."
+    "To run the code, install the following packages. Please use this SDK package version as mentioned in [LangChain docs](https://python.langchain.com/docs/integrations/vectorstores/azuresearch) `azure-search-documents==11.4.0b8`."
    ]
   },
   {
@@ -16,7 +16,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! pip install azure-search-documents --pre \n",
+    "! pip install azure-search-documents==11.4.0b8 \n",
     "! pip install openai\n",
     "! pip install python-dotenv\n",
     "! pip install langchain"


### PR DESCRIPTION
Thank you for creating and sharing these code samples. I was attempting to run `demo-python/code/azure-search-vector-python-langchain-sample.ipynb` but got the following error and warnings - 

![image](https://github.com/Azure/cognitive-search-vector-pr/assets/94559048/4c38abc8-6cb1-4e0b-af8d-ffe04acb3a1c)

![image](https://github.com/Azure/cognitive-search-vector-pr/assets/94559048/742df0aa-f48e-46ff-8f13-cd43626fb193)

Upon further investigation, found out that the latest pre-release version of `azure-search-documents` contains breaking changes. We need to lock down the specific version of this package as per LangChain docs https://python.langchain.com/docs/integrations/vectorstores/azuresearch. Here's the fix for it, which I have tested locally.