### PR TITLE
Fix incorrect usage of `begin_analyze_document` - missing `body` parameter

### DIFF
--- a/demo-python/code/indexers/document-intelligence-custom-skill/api/functions/function_app.py
+++ b/demo-python/code/indexers/document-intelligence-custom-skill/api/functions/function_app.py
@@ -236,7 +236,7 @@ async def process_file(client: DocumentIntelligenceClient, record_id: str, file:
 
     try:
         poller = await client.begin_analyze_document(
-            "prebuilt-layout", analyze_request=file_data, content_type="application/octet-stream", output_content_format=mode, features=["ocrHighResolution"]
+            "prebuilt-layout", body=file_data, content_type="application/octet-stream", output_content_format=mode, features=["ocrHighResolution"]
         )
         result = await poller.result()
         return {
@@ -257,7 +257,7 @@ async def process_file(client: DocumentIntelligenceClient, record_id: str, file:
 async def process_sas_uri(client: DocumentIntelligenceClient, record_id: str, sas_uri: str, mode: str):
     try:
         poller = await client.begin_analyze_document(
-            "prebuilt-layout", analyze_request=AnalyzeDocumentRequest(url_source=sas_uri), output_content_format=mode, features=["ocrHighResolution"]
+            "prebuilt-layout", body=AnalyzeDocumentRequest(url_source=sas_uri), output_content_format=mode, features=["ocrHighResolution"]
         )
         result = await poller.result()
         return {


### PR DESCRIPTION
This PR fixes a `TypeError` caused by incorrect usage of the `begin_analyze_document` method from the `azure.ai.documentintelligence` SDK. The method requires the model ID as the first argument and the request payload to be passed explicitly using the `body=` keyword, which may have been introduced in a recent SDK version.

**What Changed**
Updated both `process_file` and `process_sas_uri` functions to correctly pass the request payload using `body=`.

Ensures compatibility with the current SDK version, where the `body` parameter is mandatory.

See the official documentation for reference: [DocumentIntelligenceClient Class](https://learn.microsoft.com/en-us/python/api/azure-ai-documentintelligence/azure.ai.documentintelligence.documentintelligenceclient?view=azure-python#azure-ai-documentintelligence-documentintelligenceclient-begin-analyze-document)

**Why**
Without this fix, Azure Functions that use this method as part of the custom skill fail with a TypeError:

```
Result: Failure Exception: TypeError: DocumentIntelligenceClientOperationsMixin.begin_analyze_document() missing 1 required positional argument: 'body' Stack: File "/azure-functions-host/workers/python/3.10/LINUX/X64/azure_functions_worker/dispatcher.py", line 674, in _handle__invocation_request await self._run_async_func(fi_context, fi.func, args) File "/azure-functions-host/workers/python/3.10/LINUX/X64/azure_functions_worker/dispatcher.py", line 1012, in _run_async_func return await ExtensionManager.get_async_invocation_wrapper( File "/azure-functions-host/workers/python/3.10/LINUX/X64/azure_functions_worker/extension.py", line 143, in get_async_invocation_wrapper result = await function(**args) File "/home/site/wwwroot/function_app.py", line 204, in ReadDocument result_content.append(await process_sas_uri(client, record_id, data["sas_uri"], data["mode"])) # type: ignore File "/home/site/wwwroot/function_app.py", line 259, in process_sas_uri poller = await client.begin_analyze_document( File "/home/site/wwwroot/.python_packages/lib/site-packages/azure/core/tracing/decorator_async.py", line 119, in wrapper_use_tracer return await func(*args, **kwargs)
```