### PR TITLE
Clarify integrated vectorization authentication

### DIFF
--- a/demo-python/code/.env-sample
+++ b/demo-python/code/.env-sample
@@ -29,8 +29,11 @@ AZURE_AI_SERVICES_KEY=
 
 # Used for azure-search-integrated-vectorization-sample
 AZURE_OPENAI_ENDPOINT=your-openai-endpoint
-# Optional, only required if not using RBAC authentication
+# Required unless AZURE_OPENAI_USE_MANAGED_IDENTITY is true
 AZURE_OPENAI_KEY=
+# Set to true only after enabling a managed identity on the search service and
+# assigning it Cognitive Services OpenAI User on the Azure OpenAI resource
+AZURE_OPENAI_USE_MANAGED_IDENTITY=false
 AZURE_OPENAI_EMBEDDING_DEPLOYMENT=text-embedding-3-large
 
 # Used for ragas

--- a/demo-python/code/integrated-vectorization/azure-search-integrated-vectorization-sample.ipynb
+++ b/demo-python/code/integrated-vectorization/azure-search-integrated-vectorization-sample.ipynb
@@ -21,6 +21,8 @@
     "\n",
     "+ A deployment of the `text-embedding-3-large` model on Azure OpenAI. Make sure the deployment has sufficient [tokens per minute (TPM) quota](https://learn.microsoft.com/azure/ai-foundry/openai/how-to/quota) for the documents you plan to index. The TPM allocation also determines the deployment's requests per minute (RPM) rate limit.\n",
     "\n",
+    "+ Azure OpenAI access for the search service. Use an Azure OpenAI key, or explicitly enable managed identity in `.env` after assigning the search service identity **Cognitive Services OpenAI User** on the Azure OpenAI resource. A role assigned only to the notebook user doesn't authorize query-time vectorization by the search service.\n",
+    "\n",
     "+ Azure Blob Storage. This notebook connects to your storage account and loads a container with the sample PDFs.\n"
    ]
   },
@@ -60,6 +62,8 @@
    "source": [
     "### Load .env file (Copy .env-sample to .env and update accordingly)\n",
     "\n",
+    "For the quickest setup, provide `AZURE_OPENAI_KEY`. To use the search service's managed identity instead, leave the key empty and set `AZURE_OPENAI_USE_MANAGED_IDENTITY=true` only after configuring the identity and role assignment described in the prerequisites. The next cell rejects an accidental empty key instead of allowing a delayed vectorization 401.\n",
+    "\n",
     "Optionally, you can test the following features of integrated vectorization using this notebook by setting the appropriate environment variables below:\n",
     "\n",
     "1. [OCR](https://learn.microsoft.com/en-us/azure/search/cognitive-search-skill-ocr) every page using the built-in OCR functionality. This allows you to add page numbers for every chunk that is extracted. It requires an [AI Services account](https://learn.microsoft.com/en-us/azure/search/cognitive-search-attach-cognitive-services)\n",
@@ -92,7 +96,13 @@
     "search_blob_connection_string = os.getenv(\"SEARCH_BLOB_DATASOURCE_CONNECTION_STRING\", blob_connection_string)\n",
     "blob_container_name = os.getenv(\"BLOB_CONTAINER_NAME\", \"int-vec\")\n",
     "azure_openai_endpoint = os.environ[\"AZURE_OPENAI_ENDPOINT\"]\n",
-    "azure_openai_key = os.getenv(\"AZURE_OPENAI_KEY\")\n",
+    "azure_openai_key = os.getenv(\"AZURE_OPENAI_KEY\", \"\").strip()\n",
+    "azure_openai_use_managed_identity = os.getenv(\"AZURE_OPENAI_USE_MANAGED_IDENTITY\", \"false\").lower() == \"true\"\n",
+    "if azure_openai_key and azure_openai_use_managed_identity:\n",
+    "    raise ValueError(\"Set either AZURE_OPENAI_KEY or AZURE_OPENAI_USE_MANAGED_IDENTITY=true, not both.\")\n",
+    "if not azure_openai_key and not azure_openai_use_managed_identity:\n",
+    "    raise ValueError(\"AZURE_OPENAI_KEY must be set unless AZURE_OPENAI_USE_MANAGED_IDENTITY=true. Managed identity also requires the search service identity to have Cognitive Services OpenAI User on the Azure OpenAI resource.\")\n",
+    "azure_openai_key = azure_openai_key or None\n",
     "azure_openai_embedding_deployment = os.getenv(\"AZURE_OPENAI_EMBEDDING_DEPLOYMENT\", \"text-embedding-3-large\")\n",
     "azure_openai_model_name = os.getenv(\"AZURE_OPENAI_EMBEDDING_MODEL_NAME\", \"text-embedding-3-large\")\n",
     "azure_openai_model_dimensions = int(os.getenv(\"AZURE_OPENAI_EMBEDDING_DIMENSIONS\", 1024))\n",

--- a/demo-python/code/integrated-vectorization/readme.md
+++ b/demo-python/code/integrated-vectorization/readme.md
@@ -32,6 +32,10 @@ The code reads the `data/text-sample.json` file, which contains the input string
 
 - A deployment of the `text-embedding-3-large` or `text-embedding-3-small` embedding model in your Azure OpenAI service. We recommend Azure OpenAI REST API version `2024-10-21`. As a naming convention, we name deployments after the model name: "text-embedding-3-large".
 
+- Azure OpenAI access for the search service. Choose one authentication mode:
+  - For key-based authentication, set `AZURE_OPENAI_KEY` to a key from the Azure OpenAI resource and leave `AZURE_OPENAI_USE_MANAGED_IDENTITY` set to `false`.
+  - For managed identity, leave `AZURE_OPENAI_KEY` empty, set `AZURE_OPENAI_USE_MANAGED_IDENTITY` to `true`, enable a system-assigned managed identity on the Azure AI Search service, and assign that identity **Cognitive Services OpenAI User** on the Azure OpenAI resource. Assigning this role to the notebook user does not authorize the search service.
+
 - Python (these instructions were tested with version 3.11.x)
 
 We used Visual Studio Code with the [Python extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python) and [Jupyter extension](https://marketplace.visualstudio.com/items?itemName=ms-toolsai.jupyter) to test this sample.
@@ -53,6 +57,8 @@ We used Visual Studio Code with the [Python extension](https://marketplace.visua
 ## Troubleshoot errors
 
 If the notebook preflight or **Search Explorer** can't query the index, verify the search service's **Settings > Keys** selection matches the credential mode described in the prerequisites. For role-based access, also verify that your portal identity has **Search Index Data Reader** or **Search Index Data Contributor**. If access succeeds but the document count is zero, wait for the indexer to complete and review its execution history for errors.
+
+If a vector query returns **The vectorization endpoint returned status code '401'**, Azure AI Search couldn't authenticate to Azure OpenAI. Verify the authentication mode described in the prerequisites. For key-based authentication, confirm `AZURE_OPENAI_KEY` belongs to the resource named by `AZURE_OPENAI_ENDPOINT`. For managed identity, confirm the search service's identity has **Cognitive Services OpenAI User** on that Azure OpenAI resource. After correcting authentication, rerun the cells that create the index and skillset so their stored vectorizer and embedding-skill configuration is updated.
 
 If you get error 429 from Azure OpenAI, it means the resource is over capacity:
 


### PR DESCRIPTION
## Summary
- require explicit opt-in before the integrated-vectorization notebook uses the search service managed identity for Azure OpenAI
- fail during configuration when neither an Azure OpenAI key nor managed identity is selected
- document the required `Cognitive Services OpenAI User` assignment and 401 recovery steps

## Validation
- executed the complete notebook in an isolated e1111 environment using disposable Search, Azure OpenAI, and Storage resources
- indexer completed successfully with 6 documents processed and 0 failures
- independently repeated the issue's `VectorizableTextQuery` and received a positive-scoring result without a 401
- deleted the disposable resource group and confirmed it no longer exists

Fixes #325